### PR TITLE
Add Helix-compatible highlights.scm and locals.scm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "TreeSitterErlang",
+    platforms: [.macOS(.v13), .iOS(.v15)],
     products: [
         .library(name: "TreeSitterErlang", targets: ["TreeSitterErlang"]),
     ],

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,181 @@
+; Comments
+(tripledot) @comment.unused
+
+[(comment) (line_comment) (shebang)] @comment
+
+; Basic types
+(variable) @variable
+(atom) @string.special.symbol
+((atom) @constant.builtin.boolean
+ (#any-of? @constant.builtin.boolean "true" "false"))
+[(string) (sigil)] @string
+(character) @constant.character
+(escape_sequence) @constant.character.escape
+
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+
+; Punctuation
+["," "." "-" ";"] @punctuation.delimiter
+["(" ")" "#" "{" "}" "[" "]" "<<" ">>"] @punctuation.bracket
+
+; Operators
+(binary_operator operator: _ @operator)
+(unary_operator operator: _ @operator)
+["/" ":" "->"] @operator
+
+(binary_operator
+  left: (atom) @function
+  operator: "/"
+  right: (integer) @constant.numeric.integer)
+
+((binary_operator operator: _ @keyword.operator)
+ (#match? @keyword.operator "^\\w+$"))
+((unary_operator operator: _ @keyword.operator)
+ (#match? @keyword.operator "^\\w+$"))
+
+; Functions
+(function_clause name: (atom) @function)
+(call module: (atom) @namespace)
+(call function: (atom) @function)
+(stab_clause name: (atom) @function)
+(function_capture module: (atom) @namespace)
+(function_capture function: (atom) @function)
+
+; Keywords
+(attribute name: (atom) @keyword)
+
+["case" "fun" "if" "of" "when" "end" "receive" "try" "catch" "after" "begin" "maybe"] @keyword
+
+; Attributes
+; module declaration
+(attribute
+  name: (atom) @keyword
+  (arguments (atom) @namespace)
+ (#any-of? @keyword "module" "behaviour" "behavior"))
+
+(attribute
+  name: (atom) @keyword
+  (arguments
+    .
+    (atom) @namespace)
+ (#eq? @keyword "import"))
+
+(attribute
+  name: (atom) @keyword
+  (arguments
+    .
+    [(atom) @type (macro)]
+    [
+      (tuple (atom)? @variable.other.member)
+      (tuple
+        (binary_operator
+          left: (atom) @variable.other.member
+          operator: ["=" "::"]))
+      (tuple
+        (binary_operator
+          left:
+            (binary_operator
+              left: (atom) @variable.other.member
+              operator: "=")
+          operator: "::"))
+      ])
+ (#eq? @keyword "record"))
+
+(attribute
+  name: (atom) @keyword
+  (arguments
+    .
+    [
+      (atom) @constant
+      (variable) @constant
+      (call
+        function:
+          [(variable) (atom)] @keyword.directive)
+    ])
+ (#eq? @keyword "define"))
+
+(attribute
+  name: (atom) @keyword
+  (arguments
+    (_) @keyword.directive)
+ (#any-of? @keyword "ifndef" "ifdef"))
+
+(attribute
+  name: (atom) @keyword
+  module: (atom) @namespace
+ (#any-of? @keyword "spec" "callback"))
+
+(attribute
+  name: (atom) @keyword
+  (arguments [
+    (string)
+    (sigil)
+  ] @comment.block.documentation)
+ (#any-of? @keyword "doc" "moduledoc"))
+
+; Parameters
+; specs
+((attribute
+   name: (atom) @keyword
+   (stab_clause
+     pattern: (arguments (variable)? @variable.parameter)
+     body: (variable)? @variable.parameter))
+ (#any-of? @keyword "spec" "callback"))
+; functions
+(function_clause pattern: (arguments (variable) @variable.parameter))
+; anonymous functions
+(stab_clause pattern: (arguments (variable) @variable.parameter))
+; parametric types
+((attribute
+    name: (atom) @keyword
+    (arguments
+      (binary_operator
+        left: (call (arguments (variable) @variable.parameter))
+        operator: "::")))
+ (#any-of? @keyword "type" "opaque" "nominal"))
+; macros
+((attribute
+   name: (atom) @keyword
+   (arguments
+     (call (arguments (variable) @variable.parameter))))
+ (#eq? @keyword "define"))
+
+; Records
+(record_content
+  (binary_operator
+    left: (atom) @variable.other.member
+    operator: "="))
+
+(record field: (atom) @variable.other.member)
+(record name: (atom) @type)
+
+; Ignored variables
+((variable) @comment.unused
+ (#match? @comment.unused "^_"))
+
+; Macros
+(macro
+  "?"+ @keyword.directive
+  name: (_) @keyword.directive)
+
+(macro
+  "?"+ @constant
+  name: (_) @constant
+  !arguments)
+
+; Function names must beat the blanket (atom) @string.special.symbol rule.
+; Three-part captures tie on specificity and win via later pattern index.
+(function_clause name: (atom) @function.method.name)
+(stab_clause name: (atom) @function.method.name)
+(call function: (atom) @function.method.name)
+(function_capture function: (atom) @function.method.name)
+((attribute
+   name: (atom) @keyword
+   (stab_clause
+     name: (atom) @function.method.name))
+ (#any-of? @keyword "spec" "callback"))
+(binary_operator
+  left: (atom) @function.method.name
+  operator: "/"
+  right: (integer) @constant.numeric.integer)

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,0 +1,26 @@
+; Specs and Callbacks
+(attribute
+  (stab_clause
+    pattern: (arguments (variable)? @local.definition.variable.parameter)
+    ; If a spec uses a variable as the return type (and later a `when` clause to type it):
+    body: (variable)? @local.definition.variable.parameter)) @local.scope
+
+; parametric `-type`s
+((attribute
+    name: (atom) @_keyword
+    (arguments
+      (binary_operator
+        left: (call (arguments (variable) @local.definition.variable.parameter))
+        operator: "::") @local.scope))
+ (#any-of? @_keyword "type" "opaque" "nominal"))
+
+; `fun`s
+(anonymous_function (stab_clause pattern: (arguments (variable) @local.definition.variable.parameter))) @local.scope
+
+; Ordinary functions
+((function_clause
+   pattern: (arguments (variable) @local.definition.variable.parameter)) @local.scope
+ (#not-match? @local.definition.variable.parameter "^_"))
+
+(variable) @local.reference
+(macro (variable)) @_


### PR DESCRIPTION
## Summary
- Add `queries/highlights.scm` and `queries/locals.scm` based on Helix `erlang` queries.
- Include function-name captures (`@function.method.name`) so they beat the blanket `(atom) @string.special.symbol` rule (same specificity, later pattern wins).
- Declare SPM platforms macOS 13 / iOS 15. `Package.swift` already copies `queries/`; this makes that resource usable.

## Why
The package declares `.copy("queries")` but shipped no query files. Swift / Helix-style consumers need highlights (and locals) in the SPM bundle to avoid app-side query patching.

Based on current `main` (`d85b18e`).

## Test plan
- [ ] Load `queries/highlights.scm` / `locals.scm` against the erlang grammar
- [ ] Spot-check function clause / call names vs bare atoms (e.g. `nil`)


Made with [Cursor](https://cursor.com)